### PR TITLE
use srun to parallelize if the cluster is slurm

### DIFF
--- a/template/bin/rsh.erb
+++ b/template/bin/rsh.erb
@@ -5,6 +5,10 @@
 # environment breaking `pbsrsh`, so I created a simple alternative
 #
 
+<%-
+  torque_cluster = OodAppkit.clusters[context.cluster].job_config[:adapter] == 'torque'
+-%>
+
 module purge
 
 echo "Arguments = ${@}" >> <%= session.staged_root.join("rsh.log") %>
@@ -32,4 +36,8 @@ shift $((OPTIND-1))
 echo "Submitted Arguments = ${HOST} ${*}" >> <%= session.staged_root.join("rsh.log") %>
 
 # CFX likes to wrap entire command + args as a single argument
+<%- if torque_cluster -%>
 exec pbsdsh -o -h "${HOST}" sh -c "${*}"
+<% else %>
+exec srun -w "${HOST}" --ntasks 1 --nodes 1 sh -c "${*}"
+<% end %>

--- a/template/bin/ssh.erb
+++ b/template/bin/ssh.erb
@@ -40,5 +40,5 @@ echo "Submitted Arguments = ${HOST} ${*}" >> <%= session.staged_root.join("ssh.l
 <%- if torque_cluster -%>
 exec pbsdsh -o -h "${HOST}" sh -c "${*}"
 <% else %>
-exec srun -w "${HOST}" --ntasks 1 --nodes 1 sh -c "${*}"
+exec srun -w "${HOST}" --ntasks 1 --nodes 1 /bin/bash -c "${*}"
 <% end %>

--- a/template/bin/ssh.erb
+++ b/template/bin/ssh.erb
@@ -6,6 +6,10 @@
 # to update in the future.
 #
 
+<%-
+  torque_cluster = OodAppkit.clusters[context.cluster].job_config[:adapter] == 'torque'
+-%>
+
 module purge
 
 echo "Arguments = ${@}" >> <%= session.staged_root.join("ssh.log") %>
@@ -33,4 +37,8 @@ shift $((OPTIND-1))
 echo "Submitted Arguments = ${HOST} ${*}" >> <%= session.staged_root.join("ssh.log") %>
 
 # CFX likes to wrap entire command + args as a single argument
+<%- if torque_cluster -%>
 exec pbsdsh -o -h "${HOST}" sh -c "${*}"
+<% else %>
+exec srun -w "${HOST}" --ntasks 1 --nodes 1 sh -c "${*}"
+<% end %>


### PR DESCRIPTION
use srun to parallelize if the cluster is slurm.

I'm putting this in draft initially just because I need some confirmation that the srun command is really the equivalent of the pbsdsh. 