### PR TITLE
Account select

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -1,10 +1,12 @@
+<%-
+  groups = OodSupport::User.new.groups.map(&:name).reject { |group| /^P.+$/.match(group).nil? }
+-%>
 ---
 cluster:
   - "owens"
-  - "owens-slurm"
 form:
   - version
-  - bc_account
+  - account
   - bc_num_hours
   - bc_num_slots
   - num_cores
@@ -31,9 +33,13 @@ attributes:
       Currently only Fluent and CFX have been tested to support multiple nodes.
   bc_vnc_resolution:
     required: true
-  bc_account:
+  account:
     label: "Project"
-    help: "You can leave this blank if **not** in multiple projects."
+    widget: select
+    options:
+    <%- groups.each do |group| -%>
+      - "<%= group %>"
+    <%- end -%>
   reserve_parallel_licenses:
     widget: check_box
     checked_value: 1

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -1,5 +1,7 @@
 <%-
-  groups = OodSupport::User.new.groups.map(&:name).reject { |group| /^P.+$/.match(group).nil? }
+  groups = OodSupport::User.new.groups.sort_by(&:id).tap { |groups|
+    groups.unshift(groups.delete(OodSupport::Process.group))
+  }.map(&:name).grep(/^P./)
 -%>
 ---
 cluster:

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -1,10 +1,9 @@
 <%-
   nodes = bc_num_slots.blank? ? 1 : bc_num_slots.to_i
   num_cpus_for_free = 4
-  torque_cluster = OodAppkit.clusters[cluster].job_config[:adapter] == 'torque'
   ppn = if num_cores.blank?
           28
-        elsif nodes > 1 && !torque_cluster
+        elsif nodes > 1
           # slurm cluster is going to get the whole node if requesting more than 1 node
           # so be sure you request 28 cores for the license calculations below
           28
@@ -17,24 +16,17 @@
     ppn = 48
     partition = bc_num_slots.to_i > 1 ? "hugemem-parallel" : "hugemem"
     slurm_args = [ "--nodes", "#{nodes}", "--ntasks-per-node", "#{ppn}", "--partition", partition ]
-    torque_args = "#{nodes}:ppn=#{ppn}:#{node_type}"
   when "vis"
     slurm_args = ["--nodes", "#{nodes}", "--ntasks-per-node", "#{ppn}", "--gpus-per-node", "1", "--gres", "vis" ]
-    torque_args = "#{nodes}:ppn=#{ppn}:#{node_type}:gpus=1"
   else
     slurm_args = ["--nodes", "#{nodes}", "--ntasks-per-node", "#{ppn}" ]
-    torque_args = "#{nodes}:ppn=#{ppn}"
   end
 
   licensed_cpus = (nodes * ppn) - num_cpus_for_free
   # Do not attempt to reserve negative licenses
   need_parallel_licenses = reserve_parallel_licenses.to_i == 1 && licensed_cpus > 0
 
-  if torque_cluster
-    licenses = need_parallel_licenses ? "ansys+1%ansyspar+#{licensed_cpus}" : "ansys+1"
-  else
-    licenses = need_parallel_licenses ? "ansys@osc:1,ansyspar@osc:#{licensed_cpus}" : "ansys@osc:1"
-  end
+  licenses = need_parallel_licenses ? "ansys@osc:1,ansyspar@osc:#{licensed_cpus}" : "ansys@osc:1"
 
   slurm_args += [ "--licenses", licenses ]
 %>
@@ -43,12 +35,6 @@ batch_connect:
   template: "vnc"
 script:
   native:
-  <%- if torque_cluster %>
-    resources:
-      nodes: "<%= torque_args %>"
-      software: "<%= licenses %>"
-  <%- else %>
   <%- slurm_args.each do |arg| %>
     - "<%= arg %>"
-  <%- end %>
   <%- end %>

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -35,6 +35,7 @@ batch_connect:
   template: "vnc"
 script:
   native:
+  accounting_id: "<%= account %>"
   <%- slurm_args.each do |arg| %>
     - "<%= arg %>"
   <%- end %>

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -34,8 +34,8 @@
 batch_connect:
   template: "vnc"
 script:
-  native:
   accounting_id: "<%= account %>"
+  native:
   <%- slurm_args.each do |arg| %>
     - "<%= arg %>"
   <%- end %>

--- a/template/bin/rsh.erb
+++ b/template/bin/rsh.erb
@@ -5,10 +5,6 @@
 # environment breaking `pbsrsh`, so I created a simple alternative
 #
 
-<%-
-  torque_cluster = OodAppkit.clusters[context.cluster].job_config[:adapter] == 'torque'
--%>
-
 module purge
 
 echo "Arguments = ${@}" >> <%= session.staged_root.join("rsh.log") %>
@@ -36,8 +32,4 @@ shift $((OPTIND-1))
 echo "Submitted Arguments = ${HOST} ${*}" >> <%= session.staged_root.join("rsh.log") %>
 
 # CFX likes to wrap entire command + args as a single argument
-<%- if torque_cluster -%>
-exec pbsdsh -o -h "${HOST}" sh -c "${*}"
-<% else %>
 exec srun -w "${HOST}" --ntasks 1 --nodes 1 sh -c "${*}"
-<% end %>

--- a/template/bin/ssh.erb
+++ b/template/bin/ssh.erb
@@ -6,10 +6,6 @@
 # to update in the future.
 #
 
-<%-
-  torque_cluster = OodAppkit.clusters[context.cluster].job_config[:adapter] == 'torque'
--%>
-
 module purge
 
 echo "Arguments = ${@}" >> <%= session.staged_root.join("ssh.log") %>
@@ -37,8 +33,4 @@ shift $((OPTIND-1))
 echo "Submitted Arguments = ${HOST} ${*}" >> <%= session.staged_root.join("ssh.log") %>
 
 # CFX likes to wrap entire command + args as a single argument
-<%- if torque_cluster -%>
-exec pbsdsh -o -h "${HOST}" sh -c "${*}"
-<% else %>
 exec srun -w "${HOST}" --ntasks 1 --nodes 1 /bin/bash -c "${*}"
-<% end %>


### PR DESCRIPTION
This PR moves `bc_account` to an `account` select item to force users to supply an account.

It also removes all the torque related items because they're not necessary anymore.