### PR TITLE
Update script.sh to fix the multi-node job issue with Intel MPI

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -96,6 +96,10 @@ EOL
 # Add RSH and SSH wrappers for Fluent and CFX
 export PATH="<%= session.staged_root.join("bin") %>:${PATH}"
 
+# Fix the mulitl-node job issue with Intel MPI due to Slurm upgrade
+# https://www.osc.edu/resources/technical_support/known_issues/parallel_job_with_intelmpi_hangs
+export -n I_MPI_HYDRA_BOOTSTRAP_EXEC_EXTRA_ARGS
+
 # Launch ANSYS Workbench
 <%- if gpu -%>
 module load intel/16.0.3 virtualgl/2.6.3


### PR DESCRIPTION
Fix the mulitl-node job issue with Intel MPI due to Slurm upgrade: https://www.osc.edu/resources/technical_support/known_issues/parallel_job_with_intelmpi_hangs