### PR TITLE
check for valid users before submitting

### DIFF
--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -1,4 +1,8 @@
 <%-
+
+  err_msg = "You are not a member of the ansysflu group. Please email oschelp@osc.edu to request access to ANSYS Workbench, or use an external license."
+  raise(StandardError, err_msg) unless CurrentUser.group_names.include?('ansysflu') || user_license_provider == 'external'
+
   nodes = bc_num_slots.blank? ? 1 : bc_num_slots.to_i
   num_cpus_for_free = 4
   ppn = if num_cores.blank?


### PR DESCRIPTION
check for valid users before submitting so that the app fails fast and let's the user know what they need to do to be able to use the app.