### PR TITLE
Next version

### DIFF
--- a/form.yml
+++ b/form.yml
@@ -1,14 +1,9 @@
-<%-
-  groups = OodSupport::User.new.groups.sort_by(&:id).tap { |groups|
-    groups.unshift(groups.delete(OodSupport::Process.group))
-  }.map(&:name).grep(/^P./)
--%>
 ---
 cluster:
   - "owens"
 form:
   - version
-  - account
+  - auto_accounts
   - bc_num_hours
   - bc_num_slots
   - num_cores
@@ -34,13 +29,6 @@ attributes:
       Currently only Fluent and CFX have been tested to support multiple nodes.
   bc_vnc_resolution:
     required: true
-  account:
-    label: "Project"
-    widget: select
-    options:
-    <%- groups.each do |group| -%>
-      - "<%= group %>"
-    <%- end -%>
   reserve_parallel_licenses:
     widget: check_box
     checked_value: 1

--- a/form.yml
+++ b/form.yml
@@ -70,6 +70,7 @@ attributes:
     label: "ANSYS Workbench version"
     help: "This defines the version of ANSYS you want to load."
     options:
+    - [ "2023 R2", "ansys/2023R2" ]
     - [ "2022 R2", "ansys/2022R2" ]
     - [ "2022 R1", "ansys/2022R1" ]
     - [ "2021 R2", "ansys/2021R2" ]

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -37,7 +37,6 @@
 batch_connect:
   template: "vnc"
 script:
-  accounting_id: "<%= account %>"
   native:
   <%- slurm_args.each do |arg| %>
     - "<%= arg %>"


### PR DESCRIPTION
This adds the next version of Ansys we want to publish (2023R2) along with an update to use `auto_accounts`.

We can't use `auto_modules` at this time because there are firstsolar versions we do not want to expose to users.